### PR TITLE
Weaken guzzle version requirement to >=4 <6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle": "~5.0"
+        "guzzlehttp/guzzle": ">=4,<6"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
Now it's satisfied by Guzzle v4 and Guzzle v5 (instead of just v5).

Fixes #1 while keeps guzzle-v4-dependent apps in game.
